### PR TITLE
Fix authentication methods correctly

### DIFF
--- a/app/controllers/bbs/application_controller.rb
+++ b/app/controllers/bbs/application_controller.rb
@@ -6,8 +6,8 @@ module Bbs
 
     layout 'layouts/application'
 
-    def logged_in?; current_user end
+    def logged_in?; current_bbs_user end
 
-    helper_method :logged_in?
+    helper_method :logged_in?, :current_bbs_user
   end
 end

--- a/app/controllers/bbs/comments_controller.rb
+++ b/app/controllers/bbs/comments_controller.rb
@@ -1,6 +1,6 @@
 module Bbs
   class CommentsController < Bbs::ApplicationController
-    before_action :authenticate_user, only: %i(create)
+    before_action :authenticate_bbs_user, only: %i(create)
     before_action :set_topic
 
     def create
@@ -26,7 +26,7 @@ module Bbs
 
     def comment_params
       params.require(:comment).permit(Bbs::Comment.permitted_attributes)
-        .merge(author: current_user)
+        .merge(author: current_bbs_user)
     end
 
     def comments

--- a/app/controllers/bbs/comments_controller.rb
+++ b/app/controllers/bbs/comments_controller.rb
@@ -1,6 +1,6 @@
 module Bbs
   class CommentsController < Bbs::ApplicationController
-    before_action :authenticate_user!, only: %i(create)
+    before_action :authenticate_user, only: %i(create)
     before_action :set_topic
 
     def create

--- a/app/controllers/bbs/concerns/authenticatable.rb
+++ b/app/controllers/bbs/concerns/authenticatable.rb
@@ -4,16 +4,16 @@ module Bbs
       extend ActiveSupport::Concern
 
       included do
-        unless public_instance_methods.include?(Bbs.config.current_user)
-          define_method(:current_user) do
-            __send__ Bbs.config.current_user
-          end
+        define_method(:current_user) do
+          raise NoMethodError, "undefined method #{Bbs.config.current_user} in #{self.class.to_s}." unless respond_to?(Bbs.config.current_user)
+
+          __send__ Bbs.config.current_user
         end
 
-        unless public_instance_methods.include?(Bbs.config.authenticate_user)
-          define_method(:authenticate_user!) do
-            __send__ Bbs.config.authenticate_user
-          end
+        define_method(:authenticate_user) do
+          raise NoMethodError, "undefined method #{Bbs.config.authenticate_user} in #{self.class.to_s}." unless respond_to?(Bbs.config.authenticate_user)
+
+          __send__ Bbs.config.authenticate_user
         end
       end
     end

--- a/app/controllers/bbs/concerns/authenticatable.rb
+++ b/app/controllers/bbs/concerns/authenticatable.rb
@@ -4,13 +4,13 @@ module Bbs
       extend ActiveSupport::Concern
 
       included do
-        define_method(:current_user) do
+        define_method(:current_bbs_user) do
           raise NoMethodError, "undefined method #{Bbs.config.current_user} in #{self.class.to_s}." unless respond_to?(Bbs.config.current_user)
 
           __send__ Bbs.config.current_user
         end
 
-        define_method(:authenticate_user) do
+        define_method(:authenticate_bbs_user) do
           raise NoMethodError, "undefined method #{Bbs.config.authenticate_user} in #{self.class.to_s}." unless respond_to?(Bbs.config.authenticate_user)
 
           __send__ Bbs.config.authenticate_user

--- a/app/controllers/bbs/profiles_controller.rb
+++ b/app/controllers/bbs/profiles_controller.rb
@@ -1,26 +1,26 @@
 module Bbs
   class ProfilesController < Bbs::ApplicationController
-    before_action :authenticate_user
+    before_action :authenticate_bbs_user
 
     def edit
-      current_user.build_profile unless current_user.profile
+      current_bbs_user.build_profile unless current_bbs_user.profile
     end
 
     def create
-      if current_user.create_profile(profile_params)
+      if current_bbs_user.create_profile(profile_params)
         redirect_to edit_profile_path, notice: t('.success')
       else
-        flash.now[:alert] = current_user.profile.errors.full_messages
+        flash.now[:alert] = current_bbs_user.profile.errors.full_messages
 
         render :edit
       end
     end
 
     def update
-      if current_user.profile.update(profile_params)
+      if current_bbs_user.profile.update(profile_params)
         redirect_to edit_profile_path, notice: t('.success')
       else
-        flash.now[:alert] = current_user.profile.errors.full_messages
+        flash.now[:alert] = current_bbs_user.profile.errors.full_messages
 
         render :edit
       end

--- a/app/controllers/bbs/profiles_controller.rb
+++ b/app/controllers/bbs/profiles_controller.rb
@@ -1,6 +1,6 @@
 module Bbs
   class ProfilesController < Bbs::ApplicationController
-    before_action :authenticate_user!
+    before_action :authenticate_user
 
     def edit
       current_user.build_profile unless current_user.profile

--- a/app/controllers/bbs/topics_controller.rb
+++ b/app/controllers/bbs/topics_controller.rb
@@ -1,6 +1,6 @@
 module Bbs
   class TopicsController < Bbs::ApplicationController
-    before_action :authenticate_user, only: %i(create)
+    before_action :authenticate_bbs_user, only: %i(create)
     before_action :set_category
 
     def new
@@ -29,7 +29,7 @@ module Bbs
 
     def topic_params
       params.require(:topic).permit(Bbs::Topic.permitted_attributes)
-        .merge(author: current_user)
+        .merge(author: current_bbs_user)
     end
   end
 end

--- a/app/controllers/bbs/topics_controller.rb
+++ b/app/controllers/bbs/topics_controller.rb
@@ -1,6 +1,6 @@
 module Bbs
   class TopicsController < Bbs::ApplicationController
-    before_action :authenticate_user!, only: %i(create)
+    before_action :authenticate_user, only: %i(create)
     before_action :set_category
 
     def new

--- a/app/views/bbs/profiles/edit.html.haml
+++ b/app/views/bbs/profiles/edit.html.haml
@@ -1,4 +1,4 @@
-= form_for current_user.profile, url: bbs.profile_path, html: {class: 'bbs-form bbs-form--vertical'} do |f|
+= form_for current_bbs_user.profile, url: bbs.profile_path, html: {class: 'bbs-form bbs-form--vertical'} do |f|
   .bbs-form-group
     = f.label :avatar_url
 

--- a/test/config/04_capybara.rb
+++ b/test/config/04_capybara.rb
@@ -1,15 +1,15 @@
 Bbs::ApplicationController.class_eval do
-  class_attribute :current_user
+  class_attribute :current_bbs_user
 
-  def current_user; self.class.current_user end
+  def current_bbs_user; self.class.current_bbs_user end
 
   def authenticate_user_for_test
-    return if current_user
+    return if current_bbs_user
 
     redirect_to Bbs.config.login_path
   end
 
-  helper_method :current_user
+  helper_method :current_bbs_user
 end
 
 Bbs.configure do |config|

--- a/test/controllers/bbs/concerns/authenticatable_test.rb
+++ b/test/controllers/bbs/concerns/authenticatable_test.rb
@@ -9,11 +9,11 @@ module Bbs
       end
     end
 
-    test 'can call current_user' do
+    test 'can call current_bbs_user' do
       mock = MiniTest::Mock.new.expect(:actual_current_user, true)
       mock.class.include Bbs::Concerns::Authenticatable
 
-      mock.current_user
+      mock.current_bbs_user
 
       assert_mock mock
     end
@@ -22,14 +22,14 @@ module Bbs
       mock = MiniTest::Mock.new
       mock.class.include Bbs::Concerns::Authenticatable
 
-      assert_raises { mock.current_user }
+      assert_raises { mock.current_bbs_user }
     end
 
-    test 'can call authenticate_user' do
+    test 'can call authenticate_bbs_user' do
       mock = MiniTest::Mock.new.expect(:actual_authenticate_user, true)
       mock.class.include Bbs::Concerns::Authenticatable
 
-      mock.authenticate_user
+      mock.authenticate_bbs_user
 
       assert_mock mock
     end
@@ -38,7 +38,7 @@ module Bbs
       mock = MiniTest::Mock.new
       mock.class.include Bbs::Concerns::Authenticatable
 
-      assert_raises { mock.authenticate_user }
+      assert_raises { mock.authenticate_bbs_user }
     end
 
     teardown do

--- a/test/controllers/bbs/concerns/authenticatable_test.rb
+++ b/test/controllers/bbs/concerns/authenticatable_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+module Bbs
+  class AuthenticatableTest < ActiveSupport::TestCase
+    setup do
+      Bbs.configure do |config|
+        config.current_user = :actual_current_user
+        config.authenticate_user = :actual_authenticate_user
+      end
+    end
+
+    test 'can call current_user' do
+      mock = MiniTest::Mock.new.expect(:actual_current_user, true)
+      mock.class.include Bbs::Concerns::Authenticatable
+
+      mock.current_user
+
+      assert_mock mock
+    end
+
+    test 'raise NoMethodError if Bbs.config.current_user was undefined' do
+      mock = MiniTest::Mock.new
+      mock.class.include Bbs::Concerns::Authenticatable
+
+      assert_raises { mock.current_user }
+    end
+
+    test 'can call authenticate_user' do
+      mock = MiniTest::Mock.new.expect(:actual_authenticate_user, true)
+      mock.class.include Bbs::Concerns::Authenticatable
+
+      mock.authenticate_user
+
+      assert_mock mock
+    end
+
+    test 'raise NoMethodError if Bbs.config.authenticate_user was undefined' do
+      mock = MiniTest::Mock.new
+      mock.class.include Bbs::Concerns::Authenticatable
+
+      assert_raises { mock.authenticate_user }
+    end
+
+    teardown do
+      Bbs.configure do |config|
+        config.current_user = :current_user
+        config.authenticate_user = :authenticate_user_for_test
+      end
+    end
+  end
+end

--- a/test/helpers/login_helper.rb
+++ b/test/helpers/login_helper.rb
@@ -1,9 +1,9 @@
 module LoginHelper
   def login_as(user_name)
-    Bbs::ApplicationController.current_user = bbs_users(user_name)
+    Bbs::ApplicationController.current_bbs_user = bbs_users(user_name)
   end
 
   def logout
-    Bbs::ApplicationController.current_user = nil
+    Bbs::ApplicationController.current_bbs_user = nil
   end
 end


### PR DESCRIPTION
Fixed that authentication methods was not defined properly when the methods is already defined.

And also changed the name of the method to avoid name conflicts.

fixes #41